### PR TITLE
turn off automagic to avoid confusion

### DIFF
--- a/_episodes/01-layers-of-computing.md
+++ b/_episodes/01-layers-of-computing.md
@@ -56,6 +56,7 @@ source /data/DSST/scripts/repro_env_setup.sh
 
 ~~~
 jupyter qtconsole &
+%automagic
 ~~~
 {: .bash}
 


### PR DESCRIPTION
with automagic active ipython magics are hard to distinguish from python commands.