### PR TITLE
fixed output error from length of dna_repeat_sequence

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -117,7 +117,7 @@ print(len(dna_repeat_sequence))
 ~~~
 {: .python}
 ~~~
-11
+30
 ~~~
 {: .output}
 


### PR DESCRIPTION
dna_repeat_sequence = 'CAG' * 10
print(dna_repeat_sequence)
CAGCAGCAGCAGCAGCAGCAGCAGCAGCAG
Strings have a length (but numbers don’t).
The built-in function len counts the number of characters in a string.
print(len(dna_repeat_sequence))
11